### PR TITLE
Enhanced RISC-V Instruction Loader - Improved README & Unit Tests

### DIFF
--- a/submissions/syedowaisalishah/README.md
+++ b/submissions/syedowaisalishah/README.md
@@ -1,0 +1,59 @@
+# RISC-V Instruction Loader 🏗️  
+
+This repository contains a **RISC-V Instruction Loader** script that:  
+- Parses **YAML files** containing instruction definitions  
+- Allows **filtering based on instruction extensions**  
+- Includes **unit tests** to validate functionality and ensure the integrity of YAML files  
+
+---
+
+## Features 🚀  
+
+✅ Loads all **YAML instruction files** from the `db` directory 📂  
+✅ Supports **filtering instructions** by extension(s) 🔍  
+✅ Provides **warnings for incorrect YAML formatting** ⚠️  
+✅ Uses `Oj` for **fast and efficient JSON/YAML parsing** 🚀  
+✅ Uses `Colorize` for **enhanced terminal output** 🎨  
+✅ Includes **unit tests** using `Minitest` 🧪  
+✅ Displays results with **symbols** ✅ and ❌ for clarity  
+
+---
+
+## Installation 📦  
+
+Ensure you have **Ruby installed**. Then, install necessary dependencies:  
+
+```sh
+gem install bundler minitest yaml oj colorize
+
+```
+
+## Usage 📜  
+
+Run the script to load and filter instructions:  
+
+```sh
+ruby SubmitTask.rb
+```
+Enter comma-separated extension names: A, C
+
+### Example Output
+Instructions matching extensions ["A", "C"]:
+✅ INSTRUCTION 'add' MATCHING ["A"] FOUND IN add.yaml
+✅ INSTRUCTION 'mul' MATCHING ["A", "C"] FOUND IN mul.yaml
+❌ No matching instructions found for other extensions.
+
+## Running Unit Tests 🧪
+
+```sh
+ruby TestRiscvLoader.rb
+```
+## Unit Tests 🧪  
+
+Unit tests validate:  
+
+✔️ **Proper YAML file loading**  
+✔️ **Filtering logic**  
+✔️ **YAML file integrity in the `db` directory**  
+
+

--- a/submissions/syedowaisalishah/parser.rb
+++ b/submissions/syedowaisalishah/parser.rb
@@ -1,0 +1,115 @@
+require 'yaml'
+require 'rubygems'
+require 'bundler/setup'
+require 'oj'
+require 'set'
+require 'colorize'
+
+# Recursively fetch all YAML files from the given directory
+def get_yaml_files(directory)
+    Dir.glob(File.join(directory, "**", "*.yaml"))
+end
+  
+class RiscVInstructionLoader
+  attr_reader :instructions, :files
+
+  def initialize(directory)
+    @directory = directory
+    @instructions = []
+    @files = []
+  end
+
+  # Load all YAML files and store instructions
+  def load_files
+    @files = get_yaml_files(@directory)
+    @files.each do |file|
+      begin
+        content = File.read(file)
+        data = parse_yaml(content)
+        validate_filename(file, data)
+        @instructions << { file: file, data: data }
+      rescue StandardError => e
+        puts "❌ Error loading #{file}: #{e.message}".red
+      end
+    end
+  end
+
+  # Try parsing with Oj first, then fallback to YAML
+  def parse_yaml(content)
+    Oj.load(content) # Fast parsing
+  rescue
+    YAML.load(content) # Fallback if Oj fails
+  end
+
+  # Ensure the filename matches the instruction name inside YAML
+  def validate_filename(file, data)
+    expected_name = File.basename(file, ".yaml")
+    if data["name"] != expected_name
+      puts "⚠️  Warning: #{file} has mismatched name key (expected '#{expected_name}', found '#{data['name']}')".yellow
+    end
+  end
+
+  # Print summary of loaded files and instructions
+  def print_summary
+    puts "📂 Total YAML files loaded: #{@files.size}".cyan
+    puts "📜 Total instructions loaded: #{@instructions.size}".cyan
+  end
+
+  # Filter and display instructions that match user-provided extensions
+  def filter_by_extensions(extensions)
+    extensions = extensions.split(',').map(&:strip)
+    matching_instructions = @instructions.select do |instr|
+      defined_by = instr[:data]["definedBy"]
+      match_extension?(defined_by, extensions)
+    end
+
+    puts "\n🔍 Instructions matching extensions #{extensions.inspect}:".light_blue
+    if matching_instructions.empty?
+      puts "❌ No matching instructions found.".red
+    else
+      matching_instructions.each do |instr|
+        file_name = File.basename(instr[:file])
+        instruction_name = instr[:data]["name"]
+        puts "✅ INSTRUCTION '#{instruction_name}' MATCHING #{extensions.inspect} FOUND IN #{file_name}".green
+      end
+    end
+  end
+
+  private
+
+  # Check if an instruction matches the given extensions
+  def match_extension?(defined_by, extensions)
+    case defined_by
+    when String
+      extensions.include?(defined_by)
+    when Hash
+      match_hash(defined_by, extensions)
+    else
+      false
+    end
+  end
+
+  # Handle nested extension conditions (allOf / anyOf logic)
+  def match_hash(defined_by, extensions)
+    if defined_by.key?("allOf")
+      defined_by["allOf"].all? { |ext| match_extension?(ext, extensions) }
+    elsif defined_by.key?("anyOf")
+      defined_by["anyOf"].any? { |ext| match_extension?(ext, extensions) }
+    else
+      false
+    end
+  end
+end
+
+if __FILE__ == $0
+  db_path = File.expand_path("../../db", __dir__) # Dynamically set db path
+  puts "🗂️  Loading YAML files from: #{db_path}".cyan
+
+  loader = RiscVInstructionLoader.new(db_path)
+  loader.load_files
+  loader.print_summary
+  
+  print "\n💡 Enter comma-separated extension names: ".light_blue
+  extensions = gets.chomp
+  loader.filter_by_extensions(extensions)
+end

--- a/submissions/syedowaisalishah/test_parser.rb
+++ b/submissions/syedowaisalishah/test_parser.rb
@@ -1,0 +1,65 @@
+require 'minitest/autorun'
+require_relative 'parser'
+require 'yaml'
+
+class TestRiscVInstructionLoader < Minitest::Test
+  def setup
+    @test_dir = "test_db"
+    Dir.mkdir(@test_dir) unless Dir.exist?(@test_dir)
+
+    # Create sample YAML files for testing
+    File.write(File.join(@test_dir, "add.yaml"), { "name" => "add", "definedBy" => "A" }.to_yaml)
+    File.write(File.join(@test_dir, "sub.yaml"), { "name" => "sub", "definedBy" => "B" }.to_yaml)
+    File.write(File.join(@test_dir, "mul.yaml"), { "name" => "mul", "definedBy" => { "anyOf" => ["A", "C"] } }.to_yaml)
+
+
+    @loader = RiscVInstructionLoader.new(@test_dir)
+    @loader.load_files
+  end
+
+  def teardown
+   
+    Dir.foreach(@test_dir) { |f| File.delete(File.join(@test_dir, f)) unless File.directory?(f) }
+    Dir.rmdir(@test_dir)
+  end
+
+  # Test to verify correct loading of YAML files
+  def test_yaml_loading
+    assert_equal 3, @loader.files.size, "Should load 3 YAML files"
+    assert_equal 3, @loader.instructions.size, "Should store 3 instructions"
+  end
+
+  # Test filtering by a single extension (A)
+  def test_filter_by_single_extension
+    result = capture_io { @loader.filter_by_extensions("A") }.join
+    assert_includes result, "INSTRUCTION 'add' MATCHING [\"A\"] FOUND IN add.yaml"
+    assert_includes result, "INSTRUCTION 'mul' MATCHING [\"A\"] FOUND IN mul.yaml"
+    refute_includes result, "sub.yaml"
+  end
+
+  # Test filtering by multiple extensions (A, C)
+  def test_filter_by_multiple_extensions
+    result = capture_io { @loader.filter_by_extensions("A, C") }.join
+    assert_includes result, "INSTRUCTION 'mul' MATCHING [\"A\", \"C\"] FOUND IN mul.yaml"
+  end
+
+  def test_invalid_extension
+    result = capture_io { @loader.filter_by_extensions("X") }.join
+    assert_includes result, "❌ No matching instructions found."
+  end
+
+  # New test to verify the integrity of YAML files in the db directory
+  def test_yaml_integrity
+    db_path = File.expand_path("../../db", __dir__)
+    yaml_files = Dir.glob(File.join(db_path, "**", "*.yaml"))
+    
+    yaml_files.each do |file|
+      begin
+        YAML.load_file(file)
+      rescue Psych::SyntaxError => e
+        flunk "YAML Syntax Error in #{file}: #{e.message}"
+      end
+    end
+    assert true, "All YAML files are valid."
+  end
+end


### PR DESCRIPTION
- Adds a Ruby script to load, validate, and filter RISC-V instruction YAML files from the `db/` directory.  
- Counts total YAML files, checks filename consistency, and filters instructions based on user-provided extensions.  
- Supports both simple (`definedBy: "A"`) and complex (`allOf`, `anyOf`) extension conditions.  

#### **Implementation Details**  
- Uses `Oj` for fast parsing and `colorize` for enhanced terminal output.  
- Implements `Minitest` for unit testing, covering YAML loading, filtering, and error handling.  
- Displays warnings for filename mismatches and errors in YAML formatting.  

#### **Submission Includes**  
- `parser.rb` (main script), `test_parser.rb` (unit tests), and output screenshots.  
- Dependencies: `yaml`, `oj`, `set`, `colorize`, `minitest` (install via `gem install <package>`).  
- The script runs interactively, prompting users for extensions and displaying matching instructions.

### Screenshot
`parser.rb`
![parser](https://github.com/user-attachments/assets/83fcd869-d6c2-4997-b502-144af8f2286c)

`testparser`
![testparser](https://github.com/user-attachments/assets/b69d56ce-f841-4874-ac22-2018939146e7)
